### PR TITLE
Menambahkan Endpoint API DELETE pada fitur konsultasi

### DIFF
--- a/app/Http/Controllers/Api/ConsultationController.php
+++ b/app/Http/Controllers/Api/ConsultationController.php
@@ -52,4 +52,22 @@ class ConsultationController extends Controller
 
         return response()->json(['message' => 'Pesan berhasil dikirim.', 'data' => $message]);
     }
+
+    // ==========================================================
+    // TAMBAHKAN FUNGSI BARU DI BAWAH INI
+    // ==========================================================
+    /**
+     * Menghapus konsultasi berdasarkan ID.
+     */
+    public function destroy(Consultation $consultation)
+    {
+        // Memastikan hanya pemilik konsultasi yang bisa menghapus
+        $this->authorize('delete', $consultation);
+
+        // Hapus data dari database
+        $consultation->delete();
+
+        // Kembalikan respons sukses tanpa data (status 204)
+        return response()->json(['message' => 'Konsultasi berhasil dihapus.'], 200);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -44,6 +44,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/consultations', [ConsultationController::class, 'store']);
     Route::get('/consultations/{consultation}', [ConsultationController::class, 'show']);
     Route::post('/consultations/{consultation}/reply', [ConsultationController::class, 'reply']);
+    Route::delete('/consultations/{consultation}', [ConsultationController::class, 'destroy']);
     Route::get('/notifications', [NotificationController::class, 'index']);
     Route::post('/notifications/mark-as-read', [NotificationController::class, 'markAsRead']);
     Route::delete('/notifications/{notification}', [NotificationController::class, 'destroy']);


### PR DESCRIPTION
1. Perubahan di Route api.php, dengan menambahkan kode :
Route::delete('/consultations/{consultation}', [ConsultationController::class, 'destroy']);

2. Pada file ConsultationController.php di folder Api, menambahkan kode : public function destroy
